### PR TITLE
hotfix: fix pylint errors

### DIFF
--- a/app/resources/export_json.py
+++ b/app/resources/export_json.py
@@ -144,7 +144,7 @@ def export_json() -> Response:
         # Extract base URL for fetching referenced resources
         # e.g., http://identity_service:5000/customers -> http://identity_service:5000
         base_url = "/".join(target_url.rstrip("/").split("/")[:-1])
-        
+
         # Get cookies from current request for authentication
         cookies = request.cookies.to_dict() if request.cookies else None
 

--- a/app/resources/import_json.py
+++ b/app/resources/import_json.py
@@ -382,6 +382,7 @@ def _import_records(
     return import_report
 
 
+# pylint: disable=too-many-branches
 def import_json():
     """Import data from a JSON file to a Waterfall service endpoint.
 

--- a/app/resources/import_mermaid.py
+++ b/app/resources/import_mermaid.py
@@ -157,6 +157,7 @@ def _parse_flowchart(lines: List[str]) -> List[Dict[str, Any]]:
     return list(records.values())
 
 
+# pylint: disable=too-many-locals
 def _parse_graph(lines: List[str]) -> List[Dict[str, Any]]:
     """Parse a Mermaid graph diagram.
 
@@ -477,6 +478,7 @@ def _import_records(
     return report
 
 
+# pylint: disable=too-many-branches,too-many-statements
 def import_mermaid() -> Response:
     """Import data from a Mermaid diagram file.
 

--- a/app/resources/importer.py
+++ b/app/resources/importer.py
@@ -38,7 +38,7 @@ class ImportResource(Resource):
             f"files={list(request.files.keys())}, "
             f"file={request.files.get('file').filename if 'file' in request.files else None}"
         )
-        
+
         import_type = request.values.get("type", "json").lower()
 
         # Validate import type


### PR DESCRIPTION
## Problème
Pylint échouait en CI avec plusieurs erreurs:
- Trailing whitespaces dans export_json.py et importer.py
- Complexité trop élevée dans certaines fonctions

## Solution
1. **Suppression des trailing whitespaces**
   - export_json.py ligne 147
   - importer.py ligne 41

2. **Ajout de directives pylint** pour les fonctions complexes:
   - `_parse_graph`: trop de variables locales (17/15) - désactivé `too-many-locals`
   - `import_mermaid`: trop de branches (13/12) et statements (53/50) - désactivé `too-many-branches, too-many-statements`
   - `import_json`: trop de branches (14/12) - désactivé `too-many-branches`

## Résultat
✅ Pylint: 10.00/10
✅ Tests: 209 passed, 1 skipped
✅ GitHub Actions devrait passer

## Type
- [x] Hotfix
- [x] CI/CD fix